### PR TITLE
Util para validar emails

### DIFF
--- a/ProyectoFinal/src/logico/Utils.java
+++ b/ProyectoFinal/src/logico/Utils.java
@@ -117,24 +117,6 @@ public class Utils {
 		return null;
 	}
 
-	// Obtener una mascara para los id's
-	public static MaskFormatter getNumberMaskByPrefix(String prefix, int lenght) {
-		MaskFormatter mask = null;
-		try {
-			StringBuffer buffer = new StringBuffer();
-			for (int i = 0; i < lenght; i++) {
-				buffer.append("#");
-			}
-
-			mask = new MaskFormatter(prefix + buffer.toString());
-			mask.setPlaceholderCharacter(defaultPlaceholder);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		return mask;
-	}
-
 	// Regex para evalaur si un email es valido
 	public static boolean isAValidEmail(String email) {
 		final String regex = "^(?=.{1,64}@)[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*@" 

--- a/ProyectoFinal/src/logico/Utils.java
+++ b/ProyectoFinal/src/logico/Utils.java
@@ -4,6 +4,7 @@ import java.text.DateFormat;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
@@ -99,7 +100,7 @@ public class Utils {
 		}
 	}
 
-	// Para saber si un combobox está en el valor por defecto ("<Seleccione>")
+	// Para saber si un combobox estï¿½ en el valor por defecto ("<Seleccione>")
 	public static boolean isCbxDefaultValue(JComboBox comboBox) {
 		return comboBox.getSelectedIndex() <= 0;
 	}
@@ -114,5 +115,32 @@ public class Utils {
 			}
 		}
 		return null;
+	}
+
+	// Obtener una mascara para los id's
+	public static MaskFormatter getNumberMaskByPrefix(String prefix, int lenght) {
+		MaskFormatter mask = null;
+		try {
+			StringBuffer buffer = new StringBuffer();
+			for (int i = 0; i < lenght; i++) {
+				buffer.append("#");
+			}
+
+			mask = new MaskFormatter(prefix + buffer.toString());
+			mask.setPlaceholderCharacter(defaultPlaceholder);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+
+		return mask;
+	}
+
+	// Regex para evalaur si un email es valido
+	public static boolean isAValidEmail(String email) {
+		final String regex = "^(?=.{1,64}@)[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+)*@" 
+        + "[^-][A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(\\.[A-Za-z]{2,})$";
+		final Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+
+		return pattern.matcher(email).find();
 	}
 }


### PR DESCRIPTION
`getNumberMaskByPrefix`:
Genera una mascara de formateo para campos que requieran un ID, como en el listado de solicitudes de empresa.
Ejemplo: con `prefix="SE"` y `lenght=10`, retorna `SE__________`

`isAValidEmail`:
Evalúa si un email es válido, se puede usar en la interfaz de #21.
